### PR TITLE
fix: type error when use with rollup

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -10,7 +10,7 @@ export interface Options {
 }
 
 export type State = {
-  opts: Required<Options>
+  opts: Options
 } & { visitorContext: VisitorContext }
 
 const defaultOptions: Options = {
@@ -76,6 +76,9 @@ export default function VueNextJSX() {
               )
             }
           }
+
+          // when use with rollup state.opts maybe an empty object
+          if (!state.opts.source) return
 
           // build a new ImportDeclaration statement
           const newImportDeclaration = bt.importDeclaration(


### PR DESCRIPTION
When use with rollup ```state.opts``` maybe an empty object.